### PR TITLE
feat: Update `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ authors = [{ name = 'Sam Foreman', email = 'saforem2@gmail.com' }]
 #   'Programming Language :: Python :: Implementation :: PyPy',
 # ]
 dependencies = [
-  'mpi4py',
-  'torch',
+  # 'mpi4py',
+  # 'torch',
   'torchdata',
   'rich',
   'transformers',
@@ -39,7 +39,7 @@ dependencies = [
   'wandb',
   'tqdm',
   'ezpz @ git+https://github.com/saforem2/ezpz',
-  'ambivalent @ git+https://github.com/saforem2/ambivalent',
+  # 'ambivalent @ git+https://github.com/saforem2/ambivalent',
 ]
 
 
@@ -66,6 +66,14 @@ Source = 'https://github.com/saforem2/mmm'
 
 # Tools settings -------------------------------------------------------------------------------------------------------
 #
+[tool.uv]
+override-dependencies = [
+ "torch; sys_platform == 'never'",
+ "torchaudio; sys_platform == 'never'",
+ "torchvision; sys_platform == 'never'",
+ "mpi4py; sys_platform == 'never'",
+]
+
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -109,7 +117,7 @@ target-version = 'py310'
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ['E4', 'E7', 'E9', 'F']
-ignore = []
+ignore = ["E402"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ['ALL']
@@ -118,9 +126,12 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = '^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$'
 
+[tool.ruff.lint.pycodestyle]
+max-line-length = 79
+
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
-quote-style = 'single'
+quote-style = "single"
 
 # Like Black, indent with spaces, rather than tabs.
 indent-style = 'space'


### PR DESCRIPTION
## Copilot Summary

This pull request updates the `pyproject.toml` configuration to adjust dependencies and improve linting settings. The main changes are the commenting out of several dependencies, the addition of override rules for dependency management, and updates to the linting configuration to ignore specific warnings and enforce a maximum line length.

**Dependency management:**

* Commented out `mpi4py`, `torch`, and `ambivalent` from the main dependencies list to prevent them from being installed by default. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L26-R27) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L42-R42)
* Added a `[tool.uv]` section to override and effectively disable installation of `torch`, `torchaudio`, `torchvision`, and `mpi4py` by specifying a non-existent platform condition.

**Linting configuration:**

* Updated `[tool.ruff]` settings to ignore warning `E402` and set the target Python version to 3.10.
* Added `[tool.ruff.lint.pycodestyle]` section to enforce a maximum line length of 79 characters.
* Minor formatting update to the `quote-style` setting in `[tool.ruff.format]`.

## Summary by Sourcery

Update pyproject.toml to streamline dependency management by disabling select heavy libraries and enhance linting settings for consistent code style.

Enhancements:
- Disable default installation of mpi4py, torch, and ambivalent by commenting them out and adding uv override rules
- Refine Ruff linting configuration by ignoring E402, enforcing 79-character max line length, and standardizing quote-style formatting