### PR TITLE
chore: Remove `timm` from `pyproject.toml` for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
   # Tokenization
   'blobfile',
   'tiktoken',
-  'timm',
   # Miscellaneous
+  # 'timm',
   'torchinfo',
   'tomli',
   'wandb',


### PR DESCRIPTION
## Copilot Summary

This pull request makes a minor adjustment to the dependencies listed in `pyproject.toml`. The change comments out the `timm` package, indicating it is no longer required or should not be installed by default.